### PR TITLE
Add Middleware support for Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,6 @@ A library for building APIs with AWS Lambda & API Gateway.
 npm i @crgeary/custodian
 ```
 
-## Todo
-
--   [x] Generic Responses
--   [x] Error Handler
--   [ ] Middleware
--   [ ] Tests
-
 ## Functions
 
 ### Basic Example

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm i @crgeary/custodian
 -   [ ] Middleware
 -   [ ] Tests
 
-## Usage
+## Functions
 
 ### Basic Example
 
@@ -100,6 +100,31 @@ Output:
     body: '{ "message": "The resource could not be found." }',
     cookies: [],
 }
+```
+
+## Middleware
+
+Custodian will apply a set of default middleware useful for building JSON responses.
+
+To add custom middleware, simply supply an array of `middleware` to Custodian.
+
+```js
+import { custodian, defaultMiddleware } from '@crgeary/custodian';
+
+const AppendHeaderMiddleware = (res) => {
+    res.setHeader('X-Custom-Header', 'Hello, World!');
+};
+
+const middleware = [...defaultMiddleware, AppendHeaderMiddleware];
+
+export const handler = custodian(
+    () => {
+        return {
+            message: 'Hello, World!',
+        };
+    },
+    { middleware }
+);
 ```
 
 ## License

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ import {
     APIGatewayProxyResultV2,
 } from 'aws-lambda';
 
-import { response, ResponseInterface, ResponseObject } from './response';
+import { response, ResponseObject } from './response';
+import { runMiddleware, CustodianMiddleware, defaultMiddleware } from './middleware';
 import {
     BaseError,
     BadRequestError,
@@ -16,13 +17,17 @@ import {
     InternalServerError,
 } from './errors';
 
+interface CustodianOptions {
+    middleware?: Array<CustodianMiddleware>;
+}
+
 interface CustodianAPIGatewayProxyCallback {
     (event: APIGatewayProxyEventV2, context: Context, callback: Callback):
-        | Promise<ResponseInterface>
+        | Promise<ResponseObject>
         | Record<string, any>;
 }
 
-const custodian = (cb: CustodianAPIGatewayProxyCallback): APIGatewayProxyHandlerV2 => {
+const custodian = (cb: CustodianAPIGatewayProxyCallback, options: CustodianOptions = {}): APIGatewayProxyHandlerV2 => {
     return async (
         event: APIGatewayProxyEventV2,
         context: Context,
@@ -33,13 +38,18 @@ const custodian = (cb: CustodianAPIGatewayProxyCallback): APIGatewayProxyHandler
             if (!(r instanceof ResponseObject)) {
                 r = response(200, r);
             }
-            return r.send();
+            return (await runMiddleware(r as ResponseObject, options?.middleware || defaultMiddleware)).send();
         } catch (err) {
             let statusCode = 500;
             if (err.isCustodianError) {
                 statusCode = err.statusCode;
             }
-            return response(statusCode, { message: err.message }).send();
+            return (
+                await runMiddleware(
+                    response(statusCode, { message: err.message }),
+                    options?.middleware || defaultMiddleware
+                )
+            ).send();
         }
     };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ const custodian = (cb: CustodianAPIGatewayProxyCallback, options: CustodianOptio
 export {
     custodian,
     response,
+    defaultMiddleware,
     ResponseObject,
     BaseError,
     BadRequestError,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,18 @@
+import { ResponseObject } from './response';
+import Json from './middleware/Json';
+
+export const defaultMiddleware: Array<CustodianMiddleware> = [Json];
+
+export interface CustodianMiddleware {
+    (res: ResponseObject): void;
+}
+
+export const runMiddleware = async (
+    res: ResponseObject,
+    middleware: Array<CustodianMiddleware>
+): Promise<ResponseObject> => {
+    for (let i = 0; i < middleware.length; i++) {
+        await middleware[i](res);
+    }
+    return res;
+};

--- a/src/middleware/Json.ts
+++ b/src/middleware/Json.ts
@@ -1,0 +1,6 @@
+import { ResponseObject } from '../response';
+
+export default (res: ResponseObject): void => {
+    res.headers = { ...res.headers, 'Content-Type': 'application/json' };
+    res.body = typeof res.body !== 'string' ? JSON.stringify(res.body) : '';
+};

--- a/src/middleware/Json.ts
+++ b/src/middleware/Json.ts
@@ -1,6 +1,17 @@
 import { ResponseObject } from '../response';
 
+const isJson = (str: string): boolean => {
+    try {
+        JSON.parse(str);
+    } catch (e) {
+        return false;
+    }
+    return true;
+};
+
 export default (res: ResponseObject): void => {
-    res.headers = { ...res.headers, 'Content-Type': 'application/json' };
-    res.body = typeof res.body !== 'string' ? JSON.stringify(res.body) : '';
+    res.setHeader('Content-Type', 'application/json');
+    if (typeof res.body !== 'string' || !isJson(res.body)) {
+        res.body = JSON.stringify(res.body);
+    }
 };

--- a/src/response.ts
+++ b/src/response.ts
@@ -22,8 +22,24 @@ export class ResponseObject {
     send(): APIGatewayProxyStructuredResultV2 {
         return Object.assign({}, this);
     }
+    setHeader(name: string, value: string): void {
+        this.headers[name] = value;
+    }
+    removeHeader(name: string): boolean {
+        return delete this.headers[name];
+    }
+    getHeader(name: string): undefined | string | number | boolean {
+        return this.hasHeader(name) ? this.headers[name] : undefined;
+    }
+    hasHeader(name: string): boolean {
+        return name in this.headers;
+    }
+    getHeaders(): { [name: string]: boolean | number | string } {
+        return this.headers;
+    }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const response = (statusCode = 200, body: any = '', otherProperties = {}): ResponseObject => {
     return new ResponseObject({
         ...otherProperties,

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyStructuredResultV2 } from 'aws-lambda';
 
-export class ResponseObject implements ResponseInterface {
+export class ResponseObject {
     public isBase64Encoded;
     public statusCode;
     public body;
@@ -20,21 +20,11 @@ export class ResponseObject implements ResponseInterface {
         this.cookies = cookies;
     }
     send(): APIGatewayProxyStructuredResultV2 {
-        return Object.assign({}, this, {
-            body: typeof this.body !== 'string' ? JSON.stringify(this.body) : '',
-            headers: {
-                'Content-Type': 'application/json',
-                ...this.headers,
-            },
-        });
+        return Object.assign({}, this);
     }
 }
 
-export interface ResponseInterface extends APIGatewayProxyStructuredResultV2 {
-    send(): APIGatewayProxyStructuredResultV2;
-}
-
-export const response = (statusCode = 200, body: any = '', otherProperties = {}): ResponseInterface => {
+export const response = (statusCode = 200, body: any = '', otherProperties = {}): ResponseObject => {
     return new ResponseObject({
         ...otherProperties,
         statusCode,


### PR DESCRIPTION
Added basic support for middleware. Middleware is something like this, although likely the internals of interacting with the ResponseObject will change to use helper methods from the ResponseObject instead of directly modifying properties.

```js
import { ResponseObject } from '../response';

export default (res: ResponseObject): void => {
    res.headers = { ...res.headers, 'Content-Type': 'application/json' };
    res.body = typeof res.body !== 'string' ? JSON.stringify(res.body) : '';
};

```